### PR TITLE
Refactor filters

### DIFF
--- a/src/Actions.hs
+++ b/src/Actions.hs
@@ -22,9 +22,9 @@ import Filters
 assume selectList :: forall <q :: Entity record -> Entity User -> Bool, r1 :: Entity record -> Bool, r2 :: Entity record -> Bool, p :: Entity User -> Bool>.
   { row :: record |- {v:(Entity <r1> record) | entityVal v == row} <: {v:(Entity <r2> record) | True} }
   { row :: (Entity <r2> record) |- {v:(Entity <p> User) | True} <: {v:(Entity <q row> User) | True} }
-  FilterList<q, r1> record -> TaggedT<p, {\_ -> False}> _ [(Entity <r2> record)]
+  Filter<q, r1> record -> TaggedT<p, {\_ -> False}> _ [(Entity <r2> record)]
 @-}
-selectList :: (PersistQueryRead backend, PersistRecordBackend record backend, MonadReader backend m, MonadTIO m) => FilterList record -> TaggedT m [Entity record]
+selectList :: (PersistQueryRead backend, PersistRecordBackend record backend, MonadReader backend m, MonadTIO m) => Filter record -> TaggedT m [Entity record]
 selectList filters = do
   backend <- ask
   liftTIO . TIO $ runReaderT (Persist.selectList (toPersistFilters filters) []) backend
@@ -34,9 +34,9 @@ selectList filters = do
 assume selectFirst :: forall <q :: Entity record -> Entity User -> Bool, r1 :: Entity record -> Bool, r2 :: Entity record -> Bool, p :: Entity User -> Bool>.
   { row :: record |- {v:(Entity <r1> record) | entityVal v == row} <: {v:(Entity <r2> record) | True} }
   { row :: (Entity <r2> record) |- {v:(Entity <p> User) | True} <: {v:(Entity <q row> User) | True} }
-  FilterList<q, r1> record -> TaggedT<p, {\_ -> False}> _ (Maybe (Entity <r2> record))
+  Filter<q, r1> record -> TaggedT<p, {\_ -> False}> _ (Maybe (Entity <r2> record))
 @-}
-selectFirst :: (PersistQueryRead backend, PersistRecordBackend record backend, MonadReader backend m, MonadTIO m) => FilterList record -> TaggedT m (Maybe (Entity record))
+selectFirst :: (PersistQueryRead backend, PersistRecordBackend record backend, MonadReader backend m, MonadTIO m) => Filter record -> TaggedT m (Maybe (Entity record))
 selectFirst filters = do
   backend <- ask
   liftTIO . TIO $ runReaderT (Persist.selectFirst (toPersistFilters filters) []) backend

--- a/src/FilterTest.hs
+++ b/src/FilterTest.hs
@@ -9,18 +9,18 @@ import Filters
 userId :: UserId
 userId = undefined
 
-{-@ test1Good :: FilterList<{\_ -> True}, {\_ -> True}> _ @-}
-test1Good :: FilterList User
-test1Good = nilFL -- good
+{-@ test1Good :: Filter<{\_ _ -> True}, {\_ -> True}> _ @-}
+test1Good :: Filter User
+test1Good = trueF -- good
 
-{-@ test1Bad :: FilterList<{\_ -> True}, {\_ -> False}> _ @-}
-test1Bad :: FilterList User
-test1Bad = nilFL -- bad
+{-@ test1Bad :: Filter<{\_ _ -> True}, {\_ -> False}> _ @-}
+test1Bad :: Filter User
+test1Bad = trueF -- bad
 
-{-@ test2Good :: FilterList<{\_ -> }, {\_ -> True}> _ @-}
-test2Good :: FilterList User
-test2Good = userIdField ==. userId ?: nilFL -- good
+{-@ test2Good :: Filter<{\_ _ -> True}, {\_ -> True}> _ @-}
+test2Good :: Filter User
+test2Good = userIdField ==. userId -- good
 
-{-@ test2Bad :: FilterList<{\_ -> True}, {\_ -> True}> _ @-}
-test2Bad :: FilterList User
-test2Bad = userIdField ==. userId ?: nilFL -- bad
+{-@ test2Bad :: Filter<{\_ _ -> True}, {\_ -> True}> _ @-}
+test2Bad :: Filter User
+test2Bad = userIdField ==. userId -- bad

--- a/src/Filters.hs
+++ b/src/Filters.hs
@@ -15,92 +15,104 @@ data Filter record <
   , r :: Entity record -> Bool
   > = Filter _
 @-}
-data Filter record = Filter (Persist.Filter record)
+data Filter record = Filter { toPersistFilters :: [Persist.Filter record] }
 {-@ data variance Filter covariant contravariant covariant @-}
 
-{-@
-data FilterList record <
-    q :: Entity record -> Entity User -> Bool
-  , r :: Entity record -> Bool
-> = FilterList _
-@-}
-data FilterList a = FilterList  { toPersistFilters :: [Persist.Filter a] }
-{-@ data variance FilterList covariant contravariant covariant @-}
+{-@ assume trueF :: Filter<{\_ _ -> True}, {\_ -> True}> record @-}
+trueF :: Filter record
+trueF = Filter []
 
-{-@ assume nilFL :: FilterList<{\_ _ -> True}, {\_ -> True}> record @-}
-nilFL :: FilterList record
-nilFL = FilterList []
-
-infixr 5 ?:
+infixr 5 &&:
 {-@
-assume (?:) :: forall <r :: Entity record -> Bool, r1 :: Entity record -> Bool, r2 :: Entity record -> Bool,
-                q :: Entity record -> Entity User -> Bool, q1 :: Entity record -> Entity User -> Bool, q2 :: Entity record -> Entity User -> Bool>.
+assume (&&:) ::
+forall < r  :: Entity record -> Bool
+       , r1 :: Entity record -> Bool
+       , r2 :: Entity record -> Bool
+       , q  :: Entity record -> Entity User -> Bool
+       , q1 :: Entity record -> Entity User -> Bool
+       , q2 :: Entity record -> Entity User -> Bool
+       >.
   {row1 :: (Entity <r1> record), row2 :: (Entity <r2> record) |- {v:Entity record | v == row1 && v == row2} <: {v:(Entity <r> record) | True}}
   {row :: (Entity <r> record) |- {v:(Entity <q row> User) | True} <: {v:(Entity <q1 row> User) | True}}
   {row :: (Entity <r> record) |- {v:(Entity <q row> User) | True} <: {v:(Entity <q2 row> User) | True}}
+
   Filter<q1, r1> record ->
-  FilterList<q2, r2> record ->
-  FilterList<q, r> record
+  Filter<q2, r2> record ->
+  Filter<q, r> record
 @-}
-(?:) :: Filter record -> FilterList record -> FilterList record
-Filter f ?: FilterList fs = FilterList (f:fs)
+(&&:) :: Filter record -> Filter record -> Filter record
+Filter f1 &&: Filter f2 = Filter (f1 ++ f2)
 
 {-@
-assume (|||) :: forall <q :: Entity record -> Entity User -> Bool, r1 :: Entity record -> Bool, r2 :: Entity record -> Bool, r :: Entity record -> Bool, q1 :: Entity record -> Entity User -> Bool, q2 :: Entity record -> Entity User -> Bool>.
+assume (||:) ::
+forall < r  :: Entity record -> Bool
+       , r1 :: Entity record -> Bool
+       , r2 :: Entity record -> Bool
+       , q  :: Entity record -> Entity User -> Bool
+       , q1 :: Entity record -> Entity User -> Bool
+       , q2 :: Entity record -> Entity User -> Bool
+       >.
   {{v: Entity <r1> record | True} <: {v:(Entity <r> record) | True}}
   {{v: Entity <r2> record | True} <: {v:(Entity <r> record) | True}}
   {row :: (Entity <r> record) |- {v:(Entity <q row> User) | True} <: {v:(Entity <q1 row> User) | True}}
   {row :: (Entity <r> record) |- {v:(Entity <q row> User) | True} <: {v:(Entity <q2 row> User) | True}}
-  FilterList<q1, r1> record ->
-  FilterList<q2, r2> record ->
-  FilterList<q, r> record
+
+  Filter<q1, r1> record ->
+  Filter<q2, r2> record ->
+  Filter<q, r> record
 @-}
-(|||) :: FilterList record -> FilterList record -> FilterList record
-(FilterList f1) ||| (FilterList f2) = FilterList $ f1 Persist.||. f2
+(||:) :: Filter record -> Filter record -> Filter record
+(Filter f1) ||: (Filter f2) = Filter $ f1 Persist.||. f2
 
 -- * Combinators
 
 {-@
 (Filters.==.) ::
-forall <policy :: Entity record -> Entity User -> Bool,
-       selector :: Entity record -> typ -> Bool,
-       inverseselector :: typ -> Entity record -> Bool,
-       fieldfilter :: typ -> Bool,
-       filter :: Entity record -> Bool,
-       r :: typ -> Bool>.
+forall < policy :: Entity record -> Entity User -> Bool
+       , selector :: Entity record -> typ -> Bool
+       , inverseselector :: typ -> Entity record -> Bool
+       , fieldfilter :: typ -> Bool
+       , filter :: Entity record -> Bool
+       , r :: typ -> Bool
+       >.
   { row :: (Entity record), value :: typ<r> |- {field:(typ<selector row>) | field == value} <: typ<fieldfilter> }
   { field :: typ<fieldfilter> |- {v:(Entity <inverseselector field> record) | True} <: {v:(Entity <filter> record) | True} }
+
   EntityFieldWrapper<policy, selector, inverseselector> record typ -> typ<r> -> Filter<policy, filter> record
 @-}
 (==.) :: PersistField typ => EntityFieldWrapper record typ -> typ -> Filter record
-(EntityFieldWrapper field) ==. value = Filter (field Persist.==. value)
+(EntityFieldWrapper field) ==. value = Filter [field Persist.==. value]
 
 {-@
 (Filters.!=.) ::
-forall <policy :: Entity record -> Entity User -> Bool,
-       selector :: Entity record -> typ -> Bool,
-       inverseselector :: typ -> Entity record -> Bool,
-       fieldfilter :: typ -> Bool,
-       filter :: Entity record -> Bool,
-       r :: typ -> Bool>.
+forall < policy :: Entity record -> Entity User -> Bool
+       , selector :: Entity record -> typ -> Bool
+       , inverseselector :: typ -> Entity record -> Bool
+       , fieldfilter :: typ -> Bool
+       , filter :: Entity record -> Bool
+       , r :: typ -> Bool
+       >.
   { row :: (Entity record), value :: typ<r> |- {field:(typ<selector row>) | field != value} <: typ<fieldfilter> }
   { field :: typ<fieldfilter> |- {v:(Entity <inverseselector field> record) | True} <: {v:(Entity <filter> record) | True} }
+
   EntityFieldWrapper<policy, selector, inverseselector> record typ -> typ<r> -> Filter<policy, filter> record
 @-}
 (!=.) :: PersistField typ => EntityFieldWrapper record typ -> typ -> Filter record
-(EntityFieldWrapper field) !=. value = Filter (field Persist.!=. value)
+(EntityFieldWrapper field) !=. value = Filter [field Persist.!=. value]
 
 {-@
 (Filters.<-.) ::
-forall <policy :: Entity record -> Entity User -> Bool,
-       selector :: Entity record -> typ -> Bool,
-       inverseselector :: typ -> Entity record -> Bool,
-       fieldfilter :: typ -> Bool,
-       filter :: Entity record -> Bool,
-       r :: typ -> Bool>.
+forall < policy :: Entity record -> Entity User -> Bool
+       , selector :: Entity record -> typ -> Bool
+       , inverseselector :: typ -> Entity record -> Bool
+       , fieldfilter :: typ -> Bool
+       , filter :: Entity record -> Bool
+       , r :: typ -> Bool
+       >.
   { row :: (Entity record), value :: typ<r> |- {field:(typ<selector row>) | field == value} <: typ<fieldfilter> }
   { field :: typ<fieldfilter> |- {v:(Entity <inverseselector field> record) | True} <: {v:(Entity <filter> record) | True} }
+
   EntityFieldWrapper<policy, selector, inverseselector> record typ -> [typ<r>] -> Filter<policy, filter> record
 @-}
 (<-.) :: PersistField typ => EntityFieldWrapper record typ -> [typ] -> Filter record
-(EntityFieldWrapper field) <-. value = Filter (field Persist.<-. value)
+(EntityFieldWrapper field) <-. value = Filter [field Persist.<-. value]

--- a/src/Frankie.hs
+++ b/src/Frankie.hs
@@ -85,7 +85,7 @@ backend = getSqlBackend <$> getConfig
 {-@ assume httpAuthDb :: AuthMethod {v:(Entity User) | v == currentUser} (TaggedT<{\_ -> True}, {\_ -> False}> m)@-}
 httpAuthDb :: (MonadController w m, MonadConfig config m, HasSqlBackend config, MonadTIO m) => AuthMethod (Entity User) (TaggedT m)
 httpAuthDb = httpBasicAuth $ \username _password ->
-  mapTaggedT (reading backend) $ selectFirst (userNameField ==. username ?: nilFL)
+  mapTaggedT (reading backend) $ selectFirst (userNameField ==. username)
 
 instance WebMonad TIO where
   data Request TIO = RequestTIO { unRequestTIO :: Wai.Request }

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -128,9 +128,9 @@ home = do
   loggedInUser <- requireAuthUser
   loggedInUserId <- project userIdField loggedInUser
   loggedInUserName <- project userNameField loggedInUser
-  shares <- selectList (shareToField ==. loggedInUserId ?: nilFL)
+  shares <- selectList (shareToField ==. loggedInUserId)
   sharedFromUsers <- projectList shareFromField shares
-  sharedTodoItems <- selectList (todoItemOwnerField <-. sharedFromUsers ?: nilFL)
+  sharedTodoItems <- selectList (todoItemOwnerField <-. sharedFromUsers)
   sharedTasks <- projectList todoItemTaskField sharedTodoItems
   page <- renderTemplate Overview
     { overviewUsername = loggedInUserName

--- a/src/Tests.hs
+++ b/src/Tests.hs
@@ -42,40 +42,40 @@ id1 = undefined
 -- combinatorExample1 :: Filter User
 -- combinatorExample1 = userNameField ==. aliceText
 
--- {-@ exampleList1 :: FilterList<{\_ -> True}, {\_ -> True}> User @-}
--- exampleList1 :: FilterList User
--- exampleList1 = nilFL
+-- {-@ exampleList1 :: Filter<{\_ -> True}, {\_ -> True}> User @-}
+-- exampleList1 :: Filter User
+-- exampleList1 = trueF
 
--- -- {-@ exampleList2 :: FilterList<{\_ v -> entityKey v == id1}, {\user -> userFriend (entityVal user) == id1}> User @-}
--- -- exampleList2 :: FilterList User
--- -- exampleList2 = (userFriendField ==. id1) ?: nilFL
+-- -- {-@ exampleList2 :: Filter<{\_ v -> entityKey v == id1}, {\user -> userFriend (entityVal user) == id1}> User @-}
+-- -- exampleList2 :: Filter User
+-- -- exampleList2 = (userFriendField ==. id1)
 
--- -- {-@ exampleList3 :: FilterList<{\_ v -> entityKey v == id1}, {\user -> userFriend (entityVal user) == id1 && userName (entityVal user) == "alice"}> User @-}
--- -- exampleList3 :: FilterList User
--- -- exampleList3 = userNameField ==. "alice" ?: userFriendField ==. id1 ?: nilFL
+-- -- {-@ exampleList3 :: Filter<{\_ v -> entityKey v == id1}, {\user -> userFriend (entityVal user) == id1 && userName (entityVal user) == "alice"}> User @-}
+-- -- exampleList3 :: Filter User
+-- -- exampleList3 = userNameField ==. "alice" &&: userFriendField ==. id1
 
--- -- {-@ exampleList4 :: FilterList<{\_ v -> entityKey v == id1}, {\user -> userFriend (entityVal user) == id1 && userName (entityVal user) == "alice"}> User @-}
--- -- exampleList4 :: FilterList User
--- -- exampleList4 = userFriendField ==. id1 ?: userNameField ==. "alice" ?: nilFL
+-- -- {-@ exampleList4 :: Filter<{\_ v -> entityKey v == id1}, {\user -> userFriend (entityVal user) == id1 && userName (entityVal user) == "alice"}> User @-}
+-- -- exampleList4 :: Filter User
+-- -- exampleList4 = userFriendField ==. id1 &&: userNameField ==. "alice"
 
--- {-@ exampleList5 :: FilterList<{\row v -> entityKey v == entityKey row}, {\user -> userName (entityVal user) == "alice"}> User @-}
--- exampleList5 :: FilterList User
--- exampleList5 = userNameField ==. "alice" ?: nilFL
+-- {-@ exampleList5 :: Filter<{\row v -> entityKey v == entityKey row}, {\user -> userName (entityVal user) == "alice"}> User @-}
+-- exampleList5 :: Filter User
+-- exampleList5 = userNameField ==. "alice"
 
 -- -- {-@ exampleSelectList1 :: TaggedT<{\v -> entityKey v == id1}, {\_ -> False}> _ [{v : Entity User | userFriend (entityVal v) == id1}] @-}
 -- -- exampleSelectList1 :: TaggedT (ReaderT SqlBackend TIO) [Entity User]
 -- -- exampleSelectList1 = selectList filters
 -- --   where
--- --     {-@ filters :: FilterList<{\_ v -> entityKey v == id1}, {\v -> userFriend (entityVal v) == id1}> User @-}
--- --     filters = userFriendField ==. id1 ?: nilFL
+-- --     {-@ filters :: Filter<{\_ v -> entityKey v == id1}, {\v -> userFriend (entityVal v) == id1}> User @-}
+-- --     filters = userFriendField ==. id1
 
 -- -- {-@ exampleSelectList2 :: TaggedT<{\v -> entityKey v == id1}, {\_ -> False}> _ [{v : _ | userFriend (entityVal v) == id1 && userName (entityVal v) == "alice"}] @-}
 -- -- exampleSelectList2 :: TaggedT (ReaderT SqlBackend TIO) [Entity User]
--- -- exampleSelectList2 = selectList (userNameField ==. "alice" ?: userFriendField ==. id1 ?: nilFL)
+-- -- exampleSelectList2 = selectList (userNameField ==. "alice" &&: userFriendField ==. id1)
 
 -- {-@ exampleSelectList3 :: TaggedT<{\_ -> False}, {\_ -> False}> _ [{v : _ | userName (entityVal v) == "alice"}] @-}
 -- exampleSelectList3 :: TaggedT (ReaderT SqlBackend TIO) [Entity User]
--- exampleSelectList3 = selectList (userNameField ==. "alice" ?: nilFL)
+-- exampleSelectList3 = selectList (userNameField ==. "alice")
 
 -- -- {-@ projectSelect1 :: [{v:_ | userFriend (entityVal v) == id1}] -> TaggedT<{\_ -> False}, {\_ -> False}> Identity [{v:_ | len v == 9}] @-}
 -- -- projectSelect1 :: [Entity User] -> TaggedT Identity [String]
@@ -86,27 +86,27 @@ id1 = undefined
 -- -- {-@ names :: TaggedT<{\v -> entityKey v == id1}, {\_ -> False}> _ [String] @-}
 -- -- names :: TaggedT (ReaderT SqlBackend TIO) [String]
 -- -- names = do
--- --   rows <- selectList (userFriendField ==. id1 ?: nilFL)
+-- --   rows <- selectList (userFriendField ==. id1)
 -- --   projectList userNameField rows
 
 -- -- -- | This is bad: the result of the query is not public
 -- -- {-@ bad1 :: TaggedT<{\v -> True}, {\_ -> False}> _ [{v: _ | userFriend (entityVal v) == id1}]
 -- -- @-}
 -- -- bad1 :: TaggedT (ReaderT SqlBackend TIO) [Entity User]
--- -- bad1 = selectList (userFriendField ==. id1 ?: nilFL)
+-- -- bad1 = selectList (userFriendField ==. id1)
 
 -- -- | This is bad: who knows who else has name "alice" and is not friends with user 1?
 -- {-@ bad2 :: TaggedT<{\v -> entityKey v == id1}, {\_ -> False}> _ [{v: _ | userName (entityVal v) == "alice"}]
 -- @-}
 -- bad2 :: TaggedT (ReaderT SqlBackend TIO) [Entity User]
--- bad2 = selectList (userNameField ==. "alice" ?: nilFL)
+-- bad2 = selectList (userNameField ==. "alice")
 
 -- -- -- | This is bad: user 1 can see the filtered rows but not their SSNs
 -- -- {-@ badSSNs :: TaggedT<{\v -> entityKey v == id1}, {\_ -> False}> _ [{v:_ | len v == 9}]
 -- -- @-}
 -- -- badSSNs :: TaggedT (ReaderT SqlBackend TIO) [String]
 -- -- badSSNs = do
--- --   rows <- selectList (userFriendField ==. id1 ?: nilFL)
+-- --   rows <- selectList (userFriendField ==. id1)
 -- --   projectList userSSNField rows -- bad
 
 -- {-@
@@ -114,9 +114,9 @@ id1 = undefined
 -- @-}
 -- getSharedTasks :: Key User -> TaggedT (ReaderT SqlBackend TIO) [Text]
 -- getSharedTasks userKey = do
---   shares <- selectList (shareToField ==. userKey ?: nilFL)
+--   shares <- selectList (shareToField ==. userKey)
 --   sharedFromUsers <- projectList shareFromField shares
---   sharedTodoItems <- selectList (todoItemOwnerField <-. sharedFromUsers ?: nilFL)
+--   sharedTodoItems <- selectList (todoItemOwnerField <-. sharedFromUsers)
 --   projectList todoItemTaskField sharedTodoItems
 
 -- {-@
@@ -125,9 +125,9 @@ id1 = undefined
 -- preserveInvariant :: TaggedT (ReaderT SqlBackend TIO) [Entity Share]
 -- preserveInvariant = selectList filters
 --   where
---     {-@ filters :: FilterList<{\_ _ -> True}, {\_ -> True}> {s:Share | shared (shareFrom s) (shareTo s)} @-}
---     filters :: FilterList Share
---     filters = nilFL
+--     {-@ filters :: Filter<{\_ _ -> True}, {\_ -> True}> {s:Share | shared (shareFrom s) (shareTo s)} @-}
+--     filters :: Filter Share
+--     filters = trueF
 
 -- {-@ action1 :: TaggedT<{\viewer -> False}, {\recipient -> False}> _ _ @-}
 -- action1 :: TaggedT TIO ()
@@ -155,9 +155,9 @@ id1 = undefined
 -- @-}
 -- getSharedTasksBad :: Key User -> TaggedT (ReaderT SqlBackend TIO) [Text]
 -- getSharedTasksBad userKey = do
---   shares <- selectList nilFL
+--   shares <- selectList trueF
 --   sharedFromUsers <- projectList shareFromField shares
---   sharedTodoItems <- selectList (todoItemOwnerField <-. sharedFromUsers ?: nilFL)
+--   sharedTodoItems <- selectList (todoItemOwnerField <-. sharedFromUsers)
 --   projectList todoItemTaskField sharedTodoItems -- bad
 
 -- {-@ consumeTagged :: forall <label :: Entity User -> Bool, clear :: Entity User -> Bool>. TaggedT<label, clear> m a -> b @-}
@@ -176,24 +176,24 @@ id1 = undefined
 -- {-@ printSharedTasks' :: u:_ -> TaggedT<{\viewer -> False}, {\recipient -> True}> _ [{v: Entity Share | shareTo (entityVal v) == entityKey u}] @-}
 -- printSharedTasks' :: Entity User -> TaggedT (ReaderT SqlBackend TIO) [Entity Share]
 -- printSharedTasks' user = do
---   selectList (shareToField ==. entityKey user ?: nilFL)
+--   selectList (shareToField ==. entityKey user)
 
 
 -- {-@ printSharedTasks :: u:_ -> TaggedT<{\viewer -> False}, {\recipient -> True}> _ _ @-}
 -- printSharedTasks :: Entity User -> TaggedT (ReaderT SqlBackend TIO) ()
 -- printSharedTasks user = do
---   shares <- selectList (shareToField ==. entityKey user ?: nilFL)
+--   shares <- selectList (shareToField ==. entityKey user)
 --   sharedFromUsers <- projectList shareFromField shares
---   sharedTodoItems <- selectList (todoItemOwnerField <-. sharedFromUsers ?: nilFL)
+--   sharedTodoItems <- selectList (todoItemOwnerField <-. sharedFromUsers)
 --   tasks <- projectList todoItemTaskField sharedTodoItems
 --   printTo user $ show tasks
 
 -- {-@ printSharedTasksBad :: _ -> _ -> TaggedT<{\viewer -> False}, {\recipient -> True}> _ _ @-}
 -- printSharedTasksBad :: Entity User -> Entity User -> TaggedT (ReaderT SqlBackend TIO) ()
 -- printSharedTasksBad user1 user2 = do
---   shares <- selectList (shareToField ==. entityKey user1 ?: nilFL)
+--   shares <- selectList (shareToField ==. entityKey user1)
 --   sharedFromUsers <- projectList shareFromField shares
---   sharedTodoItems <- selectList (todoItemOwnerField <-. sharedFromUsers ?: nilFL)
+--   sharedTodoItems <- selectList (todoItemOwnerField <-. sharedFromUsersL)
 --   tasks <- projectList todoItemTaskField sharedTodoItems -- bad
 --   printTo user2 $ show tasks -- bad
 

--- a/src/Tests.hs
+++ b/src/Tests.hs
@@ -193,7 +193,7 @@ id1 = undefined
 -- printSharedTasksBad user1 user2 = do
 --   shares <- selectList (shareToField ==. entityKey user1)
 --   sharedFromUsers <- projectList shareFromField shares
---   sharedTodoItems <- selectList (todoItemOwnerField <-. sharedFromUsersL)
+--   sharedTodoItems <- selectList (todoItemOwnerField <-. sharedFromUsers)
 --   tasks <- projectList todoItemTaskField sharedTodoItems -- bad
 --   printTo user2 $ show tasks -- bad
 


### PR DESCRIPTION
Removes `FilterList` and the need to write nilFL at the end of every filter. It also generalizes the conjunction, e.g., the following filter wasn't expressible before (we were missing `FilterList` concatenation):
```
(field1 ==. val1 ||: field1 == val2) &&: (field2 == val1 ||: field2 == val2)
```