### PR TITLE
Fix --prune-unsorted

### DIFF
--- a/src/Binah/Frankie.hs
+++ b/src/Binah/Frankie.hs
@@ -52,11 +52,11 @@ instance MonadController s w m => MonadController s w (TaggedT m) where
 instance MonadController w m => MonadController w (TaggedT m) where
   request = lift request
   respond = respondTagged
-  liftWeb = lift . liftWeb
+  liftWeb x = lift (liftWeb x)
 
 {-@ assume respondTagged :: _ -> TaggedT<{\_ -> True}, {\u -> u == currentUser}> _ _ @-}
 respondTagged :: MonadController w m => Response -> TaggedT m a
-respondTagged = lift . respond
+respondTagged x = lift (respond x)
 
 {-@ assume requireAuthUser :: m {u:(Entity User) | u == currentUser} @-}
 requireAuthUser :: MonadAuth (Entity User) m => m (Entity User)
@@ -67,14 +67,14 @@ instance MonadConfig config m => MonadConfig config (TaggedT m) where
 
 instance MonadController w m => MonadController w (ReaderT r m) where
   request = lift request
-  respond = lift . respond
-  liftWeb = lift . liftWeb
+  respond x = lift (respond x)
+  liftWeb x = lift (liftWeb x)
 
 instance MonadConfig config m => MonadConfig config (ReaderT r m) where
   getConfig = lift getConfig
 
 instance MonadTIO m => MonadTIO (ConfigT config m) where
-  liftTIO = lift . liftTIO
+  liftTIO x = lift (liftTIO x)
 
 class HasSqlBackend config where
   getSqlBackend :: config -> Persist.SqlBackend
@@ -100,7 +100,7 @@ instance WebMonad TIO where
     in Wai.runSettings settings $ toWaiApplication app
 
 instance MonadTIO m => MonadTIO (ControllerT m) where
-  liftTIO = lift . liftTIO
+  liftTIO x = lift (liftTIO x)
 
 toWaiApplication :: Application TIO -> Wai.Application
 toWaiApplication app wReq wRespond = do

--- a/src/Binah/Infrastructure.hs
+++ b/src/Binah/Infrastructure.hs
@@ -34,7 +34,7 @@ liftTaggedT = TaggedT
 assume mapTaggedT :: forall <label :: Entity User -> Bool, clear :: Entity User -> Bool>. _ -> TaggedT<label, clear> _ _ -> TaggedT<label, clear> _ _
 @-}
 mapTaggedT :: (m a -> n b) -> TaggedT m a -> TaggedT n b
-mapTaggedT f = TaggedT . f . unTag
+mapTaggedT f x = TaggedT (f (unTag x))
 
 -- * Instances
 
@@ -113,10 +113,10 @@ instance MonadTIO IO where
   liftTIO = runTIO
 
 instance MonadTIO m => MonadTIO (ReaderT r m) where
-  liftTIO = lift . liftTIO
+  liftTIO x = lift (liftTIO x)
 
 instance MonadTIO m => MonadTIO (TaggedT m) where
-  liftTIO = lift . liftTIO
+  liftTIO x = lift (liftTIO x)
 
 -- Monad Transformers
 
@@ -126,4 +126,4 @@ instance MonadTrans TaggedT where
 instance MonadReader r m => MonadReader r (TaggedT m) where
   ask = lift ask
   local = mapTaggedT . local
-  reader = lift . reader
+  reader x = lift (reader x)


### PR DESCRIPTION
Is Ranjit pointed out, using `.` for composition may cause errors like:

```
  elaborate solver failed on:
      papp2 q VV##F##29 zcmp
  with error
      Unbound symbol q --- perhaps you meant: len, snd, fst ?
  in environment
      VV##F##29 := (m##a1oQ a##a1p0)      papp2 := func(4 , [(Pred @(0) @(1)); @(2); @(3); bool])      zcmp := (Binah.Test.TIO a##a1p0)
```

With this PR we no longer need to run LH with `--prune-unsorted`.