### PR TITLE
Implement insert

### DIFF
--- a/src/Binah/Actions.hs
+++ b/src/Binah/Actions.hs
@@ -81,5 +81,5 @@ projectList (EntityFieldWrapper entityField) entities = pure $ map (getConst . P
 assume printTo :: user:_ -> _ -> TaggedT<{\_ -> True}, {\viewer -> viewer == user}> _ ()
 @-}
 printTo :: MonadTIO m => Entity User -> String -> TaggedT m ()
-printTo user str = liftTIO . TIO . putStrLn . mconcat $
-  ["[", Text.unpack . userName . Persist.entityVal $ user, "] ", str]
+printTo user = liftTIO . TIO . putStrLn 
+-- . mconcat $ ["[", Text.unpack . userName . Persist.entityVal $ user, "] ", str]

--- a/src/Binah/Core.hs
+++ b/src/Binah/Core.hs
@@ -1,6 +1,6 @@
 -- | Functionality that needs to be loaded before checking the Models file.
 
-module Binah.Core ( Entity ) where
+module Binah.Core ( Entity, Key ) where
 
 import Database.Persist (Entity, Key)
 

--- a/src/Binah/Insert.hs
+++ b/src/Binah/Insert.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE GADTs #-}
+module Binah.Insert where
+
+
+import           Binah.Infrastructure
+import           Data.Text
+import           Control.Monad.Reader           ( MonadReader(..)
+                                                , runReaderT
+                                                )
+import qualified Database.Persist              as Persist
+
+import           Binah.Core
+import           Model
+
+{-@ ignore insert @-}
+{-@
+assume insert :: forall < p :: Entity record -> Bool
+                        , insertpolicy :: Entity record -> Entity User -> Bool
+                        , querypolicy  :: Entity record -> Entity User -> Bool
+                        , level    :: Entity User -> Bool
+                        , audience :: Entity User -> Bool
+                        >.
+  { rec :: (Entity<p> record) |- {v: (Entity<level> User) | True} <: {v: (Entity<insertpolicy rec> User) | True}}
+
+  { rec :: (Entity<p> record) |- {v: (Entity<querypolicy p> User) | True} <: {v: (Entity<audience> User) | True}}
+
+  BinahRecord<p, insertpolicy, querypolicy> record -> TaggedT<level, audience> _ (Key record)
+@-}
+insert
+  :: ( MonadTIO m
+     , Persist.PersistStoreWrite backend
+     , Persist.PersistRecordBackend record backend
+     , MonadReader backend m
+     )
+  => BinahRecord record
+  -> TaggedT m (Key record)
+insert record = do
+  backend <- ask
+  liftTIO . TIO $ runReaderT (Persist.insert (persistentRecord record)) backend

--- a/src/Binah/Templates.hs
+++ b/src/Binah/Templates.hs
@@ -23,6 +23,8 @@ import           Binah.Infrastructure
 import           Binah.Filters
 import           Binah.Frankie
 
+import           Model
+
 class Mustache.ToMustache d => TemplateData d where
   templateFile :: FilePath
 

--- a/src/Model.binah
+++ b/src/Model.binah
@@ -1,0 +1,15 @@
+predicate shared :: UserId -> UserId -> Bool
+
+User
+  name Text
+  ssn  Text {\user viewer -> entityKey viewer == entityKey user}
+
+TodoItem
+  owner UserId
+  task  Text   {\item viewer -> shared (todoItemOwner item) (entityKey viewer)}
+
+Share
+  from UserId
+  to   UserId
+
+  assert [shared from to]


### PR DESCRIPTION
* `BinahRecord record` is a wrapper over records. It's parameterized by 3 predicates
  - `p :: Entity record -> Bool`: This is a property over the wrapped record. In practice, it tracks the arguments used to construct the record and it's automatically generated. 
    This should actually be a predicate on `record` not `Entity record` but for technical reasons, it was way easier to implement it like this. This doesn't hurt because it shouldn't be possible to assert anything about the `entityKey` of a yet un-inserted record.
  - `insertpolicy :: Entity record -> Entity User -> Bool`: This is the user-provided insert policy.
  - `querypolicy :: Entity record -> Entity User -> Bool`: This is automatically generated and it's equal to the disjunction of all the field policies in the record. It is used to check for implicit flows when inserting. (I would love to hear a better name for this)

* Now `Model.hs` doesn't export constructors for record types. Users can only construct `BinahRecord`s using the `mk*` functions which are properly refined with the right `p`, `insertpolicy` and `querypolicy`.

* Because `Model.hs` now doesn't export data constructors I made uninterpreted functions for all fields which do get exported by LH.

* With all the above in place `insert` is pretty straightforward, it (1) checks that the security level is strong enough to imply `insertpolicy` and (2) it raises the audience to contain all users that can potentially read from the record (`querypolicy`).

Bonus: I added `{-@ LIQUID "--compile-spec" @-}` at the top of `Model.hs` which solves the problem of LH failing the first time you run it.