### PR TITLE
Updates

### DIFF
--- a/src/Binah/Actions.hs
+++ b/src/Binah/Actions.hs
@@ -4,17 +4,22 @@
 
 module Binah.Actions where
 
-import Data.Functor.Const (Const(..))
-import Control.Monad.Reader (MonadReader(..), runReaderT)
-import Database.Persist (PersistQueryRead, PersistRecordBackend, PersistEntity)
-import qualified Database.Persist as Persist
-import qualified Data.Text as Text
-import Data.Text (Text)
+import           Data.Functor.Const             ( Const(..) )
+import           Control.Monad.Reader           ( MonadReader(..)
+                                                , runReaderT
+                                                )
+import           Database.Persist               ( PersistQueryRead
+                                                , PersistRecordBackend
+                                                , PersistEntity
+                                                )
+import qualified Database.Persist              as Persist
+import qualified Data.Text                     as Text
+import           Data.Text                      ( Text )
 
-import Binah.Core
-import Binah.Infrastructure
-import Binah.Filters
-import Model
+import           Binah.Core
+import           Binah.Infrastructure
+import           Binah.Filters
+import           Model
 
 
 {-@ ignore selectList @-}
@@ -24,10 +29,18 @@ assume selectList :: forall <q :: Entity record -> Entity User -> Bool, r1 :: En
   { row :: (Entity <r2> record) |- {v:(Entity <p> User) | True} <: {v:(Entity <q row> User) | True} }
   Filter<q, r1> record -> TaggedT<p, {\_ -> False}> _ [(Entity <r2> record)]
 @-}
-selectList :: (PersistQueryRead backend, PersistRecordBackend record backend, MonadReader backend m, MonadTIO m) => Filter record -> TaggedT m [Entity record]
+selectList
+  :: ( PersistQueryRead backend
+     , PersistRecordBackend record backend
+     , MonadReader backend m
+     , MonadTIO m
+     )
+  => Filter record
+  -> TaggedT m [Entity record]
 selectList filters = do
   backend <- ask
   liftTIO . TIO $ runReaderT (Persist.selectList (toPersistFilters filters) []) backend
+
 
 {-@ ignore selectFirst @-}
 {-@
@@ -36,25 +49,39 @@ assume selectFirst :: forall <q :: Entity record -> Entity User -> Bool, r1 :: E
   { row :: (Entity <r2> record) |- {v:(Entity <p> User) | True} <: {v:(Entity <q row> User) | True} }
   Filter<q, r1> record -> TaggedT<p, {\_ -> False}> _ (Maybe (Entity <r2> record))
 @-}
-selectFirst :: (PersistQueryRead backend, PersistRecordBackend record backend, MonadReader backend m, MonadTIO m) => Filter record -> TaggedT m (Maybe (Entity record))
+selectFirst
+  :: ( PersistQueryRead backend
+     , PersistRecordBackend record backend
+     , MonadReader backend m
+     , MonadTIO m
+     )
+  => Filter record
+  -> TaggedT m (Maybe (Entity record))
 selectFirst filters = do
   backend <- ask
   liftTIO . TIO $ runReaderT (Persist.selectFirst (toPersistFilters filters) []) backend
 
 {-@ ignore project @-}
 {-@
-assume project :: forall <policy :: Entity record -> Entity User -> Bool,
-                          selector :: Entity record -> typ -> Bool,
-                          flippedselector :: typ -> Entity record -> Bool,
-                          r :: Entity record -> Bool,
-                          label :: Entity User -> Bool>.
+assume project :: forall < policy :: Entity record -> Entity User -> Bool
+                         , selector :: Entity record -> typ -> Bool
+                         , flippedselector :: typ -> Entity record -> Bool
+                         , r :: Entity record -> Bool
+                         , label :: Entity User -> Bool
+                         , capability :: Entity record -> Bool
+                         , updatepolicy :: Entity record -> Entity record -> Entity User -> Bool
+                         >.
   {row :: (Entity<r> record) |- {v:(Entity <label> User) | True} <: {v:(Entity<policy row> User) | True}}
   {row :: (Entity<r> record) |- {v:(Entity<policy row> User) | True} <: {v:(Entity <label> User) | True}}
-  EntityFieldWrapper<policy, selector, flippedselector> record typ ->
-  row:(Entity<r> record) ->
-  TaggedT<label, {\_ -> False}> _ (typ<selector row>)
+  EntityFieldWrapper<policy, selector, flippedselector, capability, updatepolicy> record typ 
+  -> row:(Entity<r> record) 
+  -> TaggedT<label, {\_ -> False}> _ (typ<selector row>)
 @-}
-project :: (PersistEntity record, Applicative m) => EntityFieldWrapper record typ -> Entity record -> TaggedT m typ
+project
+  :: (PersistEntity record, Applicative m)
+  => EntityFieldWrapper record typ
+  -> Entity record
+  -> TaggedT m typ
 project (EntityFieldWrapper entityField) = pure . getConst . Persist.fieldLens entityField Const
 
 {-@ ignore projectId @-}
@@ -62,24 +89,42 @@ project (EntityFieldWrapper entityField) = pure . getConst . Persist.fieldLens e
 assume projectId :: forall <policy :: Entity record -> Entity User -> Bool, selector :: Entity record -> Key record -> Bool, inverseselector :: Key record -> Entity record -> Bool>.
   EntityFieldWrapper<policy, selector, inverseselector> record (Key record) -> row:_ -> TaggedT<{\_ -> True}, {\_ -> False}> _ {v:_ | v == entityKey row}
 @-}
-projectId :: (PersistEntity record, Applicative m) => EntityFieldWrapper record (Key record) -> Entity record -> TaggedT m (Key record)
+projectId
+  :: (PersistEntity record, Applicative m)
+  => EntityFieldWrapper record (Key record)
+  -> Entity record
+  -> TaggedT m (Key record)
 projectId (EntityFieldWrapper entityField) = pure . getConst . Persist.fieldLens entityField Const
 
 {-@ ignore projectList @-}
 {-@
-assume projectList :: forall <r1 :: Entity record -> Bool, r2 :: typ -> Bool, policy :: Entity record -> Entity User -> Bool, p :: Entity User -> Bool, selector :: Entity record -> typ -> Bool, inverseselector :: typ -> Entity record -> Bool>.
+assume projectList :: forall < r1 :: Entity record -> Bool
+                             , r2 :: typ -> Bool
+                             , policy :: Entity record -> Entity User -> Bool
+                             , p :: Entity User -> Bool
+                             , selector :: Entity record -> typ -> Bool
+                             , inverseselector :: typ -> Entity record -> Bool
+                             , capability :: Entity record -> Bool
+                             , updatepolicy :: Entity record -> Entity record -> Entity User -> Bool
+                             >.
   { row :: (Entity <r1> record) |- {v:(Entity <p> User) | True} <: {v:(Entity <policy row> User) | True} }
   { row :: (Entity <r1> record) |- typ<selector row> <: typ<r2> }
-  EntityFieldWrapper<policy, selector, inverseselector> record typ ->
-  [(Entity <r1> record)] ->
-  TaggedT<p, {\_ -> False}> _ [typ<r2>]
+  EntityFieldWrapper<policy, selector, inverseselector, capability, updatepolicy> record typ 
+  -> [(Entity <r1> record)] 
+  -> TaggedT<p, {\_ -> False}> _ [typ<r2>]
 @-}
-projectList :: (PersistEntity record, Applicative m) => EntityFieldWrapper record typ -> [Entity record] -> TaggedT m [typ]
-projectList (EntityFieldWrapper entityField) entities = pure $ map (getConst . Persist.fieldLens entityField Const) entities
+projectList
+  :: (PersistEntity record, Applicative m)
+  => EntityFieldWrapper record typ
+  -> [Entity record]
+  -> TaggedT m [typ]
+projectList (EntityFieldWrapper entityField) entities =
+  pure $ map (getConst . Persist.fieldLens entityField Const) entities
 
 {-@
 assume printTo :: user:_ -> _ -> TaggedT<{\_ -> True}, {\viewer -> viewer == user}> _ ()
 @-}
 printTo :: MonadTIO m => Entity User -> String -> TaggedT m ()
-printTo user = liftTIO . TIO . putStrLn 
--- . mconcat $ ["[", Text.unpack . userName . Persist.entityVal $ user, "] ", str]
+printTo user = liftTIO . TIO . putStrLn
+    -- . mconcat
+    -- $ ["[", Text.unpack . userName . Persist.entityVal $ user, "] ", str]

--- a/src/Binah/Filters.hs
+++ b/src/Binah/Filters.hs
@@ -2,11 +2,11 @@
 
 module Binah.Filters where
 
-import Database.Persist (PersistField)
-import qualified Database.Persist as Persist
+import           Database.Persist               ( PersistField )
+import qualified Database.Persist              as Persist
 
-import Binah.Core
-import Model
+import           Binah.Core
+import           Model
 
 -- * Data types
 {-@
@@ -33,6 +33,7 @@ forall < r  :: Entity record -> Bool
        , q2 :: Entity record -> Entity User -> Bool
        >.
   {row1 :: (Entity <r1> record), row2 :: (Entity <r2> record) |- {v:Entity record | v == row1 && v == row2} <: {v:(Entity <r> record) | True}}
+
   {row :: (Entity <r> record) |- {v:(Entity <q row> User) | True} <: {v:(Entity <q1 row> User) | True}}
   {row :: (Entity <r> record) |- {v:(Entity <q row> User) | True} <: {v:(Entity <q2 row> User) | True}}
 
@@ -68,51 +69,63 @@ forall < r  :: Entity record -> Bool
 
 {-@
 (==.) ::
-forall < policy :: Entity record -> Entity User -> Bool
+forall < querypolicy :: Entity record -> Entity User -> Bool
        , selector :: Entity record -> typ -> Bool
        , inverseselector :: typ -> Entity record -> Bool
        , fieldfilter :: typ -> Bool
        , filter :: Entity record -> Bool
        , r :: typ -> Bool
+       , capability :: Entity record -> Bool
+       , updatepolicy :: Entity record -> Entity record -> Entity User -> Bool
        >.
   { row :: (Entity record), value :: typ<r> |- {field:(typ<selector row>) | field == value} <: typ<fieldfilter> }
   { field :: typ<fieldfilter> |- {v:(Entity <inverseselector field> record) | True} <: {v:(Entity <filter> record) | True} }
 
-  EntityFieldWrapper<policy, selector, inverseselector> record typ -> typ<r> -> Filter<policy, filter> record
+  EntityFieldWrapper<querypolicy, selector, inverseselector, capability, updatepolicy> record typ 
+  -> typ<r>
+  -> Filter<querypolicy, filter> record
 @-}
 (==.) :: PersistField typ => EntityFieldWrapper record typ -> typ -> Filter record
 (EntityFieldWrapper field) ==. value = Filter [field Persist.==. value]
 
 {-@
 (!=.) ::
-forall < policy :: Entity record -> Entity User -> Bool
+forall < querypolicy :: Entity record -> Entity User -> Bool
        , selector :: Entity record -> typ -> Bool
        , inverseselector :: typ -> Entity record -> Bool
        , fieldfilter :: typ -> Bool
        , filter :: Entity record -> Bool
        , r :: typ -> Bool
+       , capability :: Entity record -> Bool
+       , updatepolicy :: Entity record -> Entity record -> Entity User -> Bool
        >.
   { row :: (Entity record), value :: typ<r> |- {field:(typ<selector row>) | field != value} <: typ<fieldfilter> }
   { field :: typ<fieldfilter> |- {v:(Entity <inverseselector field> record) | True} <: {v:(Entity <filter> record) | True} }
 
-  EntityFieldWrapper<policy, selector, inverseselector> record typ -> typ<r> -> Filter<policy, filter> record
+  EntityFieldWrapper<querypolicy, selector, inverseselector, capability, updatepolicy> record typ 
+  -> typ<r>
+  -> Filter<querypolicy, filter> record
 @-}
 (!=.) :: PersistField typ => EntityFieldWrapper record typ -> typ -> Filter record
 (EntityFieldWrapper field) !=. value = Filter [field Persist.!=. value]
 
 {-@
 (<-.) ::
-forall < policy :: Entity record -> Entity User -> Bool
+forall < querypolicy :: Entity record -> Entity User -> Bool
        , selector :: Entity record -> typ -> Bool
        , inverseselector :: typ -> Entity record -> Bool
        , fieldfilter :: typ -> Bool
        , filter :: Entity record -> Bool
        , r :: typ -> Bool
+       , capability :: Entity record -> Bool
+       , updatepolicy :: Entity record -> Entity record -> Entity User -> Bool
        >.
   { row :: (Entity record), value :: typ<r> |- {field:(typ<selector row>) | field == value} <: typ<fieldfilter> }
   { field :: typ<fieldfilter> |- {v:(Entity <inverseselector field> record) | True} <: {v:(Entity <filter> record) | True} }
 
-  EntityFieldWrapper<policy, selector, inverseselector> record typ -> [typ<r>] -> Filter<policy, filter> record
+  EntityFieldWrapper<querypolicy, selector, inverseselector, capability, updatepolicy> record typ 
+  -> [typ<r>] 
+  -> Filter<querypolicy, filter> record
 @-}
 (<-.) :: PersistField typ => EntityFieldWrapper record typ -> [typ] -> Filter record
 (EntityFieldWrapper field) <-. value = Filter [field Persist.<-. value]

--- a/src/Binah/Insert.hs
+++ b/src/Binah/Insert.hs
@@ -20,10 +20,12 @@ assume insert :: forall < p :: Entity record -> Bool
                         , audience :: Entity User -> Bool
                         >.
   { rec :: (Entity<p> record) 
-      |- {v: (Entity User) | v == currentUser} <: {v: (Entity<insertpolicy rec> User) | True}}
+      |- {v: (Entity User) | v == currentUser} <: {v: (Entity<insertpolicy rec> User) | True}
+  }
 
   { rec :: (Entity<p> record) 
-      |- {v: (Entity<querypolicy p> User) | True} <: {v: (Entity<audience> User) | True}}
+      |- {v: (Entity<querypolicy p> User) | True} <: {v: (Entity<audience> User) | True}
+  }
 
   BinahRecord<p, insertpolicy, querypolicy> record -> TaggedT<{\_ -> True}, audience> _ (Key record)
 @-}

--- a/src/Binah/Updates.hs
+++ b/src/Binah/Updates.hs
@@ -1,0 +1,160 @@
+{-# LANGUAGE GADTs #-}
+
+{-@ LIQUID "--no-pattern-inline" @-}
+
+module Binah.Updates
+  ( assign
+  , updateWhere
+  , combine
+  )
+where
+
+import           Control.Monad.Reader
+import           Database.Persist               ( PersistRecordBackend
+                                                , PersistField
+                                                )
+import qualified Database.Persist              as Persist
+
+import           Binah.Core
+import           Binah.Filters
+import           Binah.Infrastructure
+import           Model
+
+{-@ 
+newtype Update record < visibility :: Entity record -> Entity User -> Bool
+                      , update :: Entity record -> Bool
+                      , capabilities :: Entity record -> Bool
+                      , policy :: Entity record -> Entity record -> Entity User -> Bool
+                      > = Update _ @-}
+newtype Update record = Update [Persist.Update record]
+{-@ data variance Update invariant invariant invariant invariant invariant @-}
+
+
+-- For some reason the type is not exported if we use `=.`
+{-@ ignore assign @-}
+{-@
+assume assign :: forall < policy :: Entity record -> Entity User -> Bool
+                        , selector :: Entity record -> typ -> Bool
+                        , flippedselector :: typ -> Entity record -> Bool
+                        , r :: typ -> Bool
+                        , update :: Entity record -> Bool
+                        , fieldref :: typ -> Bool
+                        , updatepolicy :: Entity record -> Entity record -> Entity User -> Bool
+                        , capability :: Entity record -> Bool
+                        >.
+  { row :: (Entity record)
+  , value :: typ<r>
+  , field :: {field:(typ<selector row>) | field == value}
+      |- {v:(Entity <flippedselector field> record) | True} <: {v:(Entity <update> record) | True}
+  }
+  
+  EntityFieldWrapper<policy, selector, flippedselector, capability, updatepolicy> record typ 
+  -> typ<r> 
+  -> Update<policy, update, capability, updatepolicy> record
+@-}
+assign :: PersistField typ => EntityFieldWrapper record typ -> typ -> Update record
+assign (EntityFieldWrapper field) val = Update [field Persist.=. val]
+
+
+-- TODO: It's probably important to make sure multiple updates to the same field don't happen at once
+{-@ ignore combine @-}
+{-@
+assume combine :: forall < visibility1 :: Entity record -> Entity User -> Bool
+                         , visibility2 :: Entity record -> Entity User -> Bool
+                         , visibility  :: Entity record -> Entity User -> Bool
+                         , update1 :: Entity record -> Bool
+                         , update2 :: Entity record -> Bool
+                         , update  :: Entity record -> Bool
+                         , cap1 :: Entity record -> Bool
+                         , cap2 :: Entity record -> Bool
+                         , cap  :: Entity record -> Bool
+                         , policy1 :: Entity record -> Entity record -> Entity User -> Bool
+                         , policy2 :: Entity record -> Entity record -> Entity User -> Bool
+                         , policy  :: Entity record -> Entity record -> Entity User -> Bool
+                         >.
+  { row :: (Entity<update> record) 
+      |- {v:(Entity<visibility1 row> User) | True} <: {v:(Entity<visibility row> User) | True} 
+  }
+  { row :: (Entity<update> record) 
+      |- {v:(Entity<visibility2 row> User) | True} <: {v:(Entity<visibility row> User) | True} 
+  }
+
+  { {v: (Entity<update> record) | True } <: {v: (Entity<update1> record) | True}}
+  { {v: (Entity<update> record) | True } <: {v: (Entity<update2> record) | True}}
+  { row1 :: (Entity<update1> record)
+  , row2 :: (Entity<update2> record) 
+      |- {v:(Entity record) | v == row1 && v == row2} <: {v:(Entity<update> record) | True} 
+  }
+
+  { {v: (Entity<cap> record) | True} <: {v: (Entity<cap1> record) | True} }
+  { {v: (Entity<cap> record) | True} <: {v: (Entity<cap2> record) | True} }
+  { row1 :: (Entity<cap1> record)
+  , row2 :: (Entity<cap2> record) 
+      |- {v:(Entity record) | v == row1 && v == row2} <: {v:(Entity<cap> record) | True} 
+  }
+
+  { old :: Entity record
+  , new :: Entity record
+     |- {v: (Entity<policy old new> User) | True } <: {v: (Entity<policy1 old new> User) | True}
+  }
+  { old :: Entity record , new :: Entity record
+     |- {v: (Entity<policy old new> User) | True } <: {v: (Entity<policy2 old new> User) | True}
+  }
+  { old :: Entity record
+  , new :: Entity record
+  , user1 :: (Entity<policy1 old new> User)
+  , user2 :: (Entity<policy2 old new> User) 
+      |- {v:(Entity User) | v == user1 && v == user2} <: {v:(Entity<policy old new> User) | True} 
+  }
+
+  Update<visibility1, update1, cap1, policy1> record
+  -> Update<visibility2, update2, cap2, policy2> record
+  -> Update<visibility,  update,  cap,  policy> record
+@-}
+combine :: Update record -> Update record -> Update record
+combine (Update us1) (Update us2) = Update (us1 ++ us2)
+
+
+-- TODO: Figure out what to do with the key
+{-@ ignore updateWhere @-}
+{-@
+assume updateWhere :: forall < visibility :: Entity record -> Entity User -> Bool
+                             , update :: Entity record -> Bool
+                             , audience :: Entity User -> Bool
+                             , capabilities :: Entity record -> Bool
+                             , updatepolicy :: Entity record -> Entity record -> Entity User -> Bool
+                             , querypolicy :: Entity record -> Entity User -> Bool
+                             , filter :: Entity record -> Bool
+                             , level :: Entity User -> Bool
+                             >.
+
+  { old  :: (Entity<filter> record)
+  , new  :: (Entity<update> record)
+  , user :: {v: (Entity<updatepolicy old new> User) | v == currentUser}
+      |- {v:(Entity record) | v == old} <: {v:(Entity<capabilities> record) | True}
+  }
+
+  { row :: (Entity<update> record) 
+      |- {v:(Entity<visibility row> User) | True} <: {v:(Entity<audience> User) | True} 
+  }
+
+  { row :: (Entity<filter> record) 
+      |- {v:(Entity<level> User) | True} <: {v:(Entity <querypolicy row> User) | True} 
+  }
+
+  Filter<querypolicy, filter> record
+  -> Update<visibility, update, capabilities, updatepolicy> record 
+  -> TaggedT<level, audience> m ()
+@-}
+updateWhere
+  :: ( MonadTIO m
+     , Persist.PersistQueryWrite backend
+     , Persist.PersistRecordBackend record backend
+     , MonadReader backend m
+     )
+  => Filter record
+  -> Update record
+  -> TaggedT m ()
+updateWhere (Filter filters) (Update up) = do
+  backend <- ask
+  liftTIO (TIO $ runReaderT (Persist.updateWhere filters up) backend)


### PR DESCRIPTION
There's a lot going on so I'll try to dissect it.

* `EntityFieldWrapper` is parameterized by two new predicates:
  * `capability :: Entity record -> Bool`: This is predicate you need to prove before updating the field. It corresponds to an uninterpreted function unique to the field and it's automatically generated.
  * `updatepolicy :: Entity record -> Entity record -> Entity User -> Bool`: This is a predicate _granting_ the capability to update the field. It's derived from a user-specified policy. More concretely, if the user writes the policy `p(x, y, z)` and the field has capability `c(x)` the `updatepolicy` on the field it's going to be `p(x, y, z) => c(x)`. The name `updatepolicy` may cause confusion because from the users point of view, `p(x, y, z)` is the policy. An alternative name could be capability-granting predicate.

* An `Update` is an object describing an update operation and it's parameterized by four predicates:
  * `visibility :: Entity record -> Entity User -> Bool`: A predicate that tracks the set of users that would be able to see the content of the update. It's used to track information flowing into updates and it corresponds to the *disjunction* of the read policies on the fields being updated.
  * `update :: Entity record -> Bool`: A predicate describing the record after applying the update. In practice this only tracks the values of the fields being updated and it cannot say anything about the rest of the fields, i.e., Binah does not know that fields not being updated stay unmodified. So, more than being a predicate on the record is a predicate on the list of pairs (field, value) being updated.
  * `capabilities :: Entity record -> Bool`: This is the cumulative set of capabilities and it always corresponds to the conjunction of the capabilities on the fields being updated.
  * `policy :: Entity record -> Entity record -> Entity User -> Bool`: This is the cumulative `upatepolicy` (or capability-granting predicate) and it always corresponds to the conjunction of the `updatepolicies` on the fields being updated.

* `assign` is the basic operation for building `Update` objects. ``field `assign` v`` constructs an `Update` object that set `field` to `v`.  First, it copies the `capability` and `updatepolicy` from the field into the `Update` object. Second, it tracks in the `update` predicate that `field` is going to be equal to `v` after the update. And finally, it set the `visibility` to the `querypolicy` of the field, because performing the update will reveal the value `v` to everyone able to see the content of `field`.

* `combine` is used to merge `Update`s by correctly *merging* the predicates. It uses conjunction for all predicates expect for the visibility which uses disjunction.

* `updateWhere` checks 3 things:
  * The security `level` is enough to perform the filter (same as `selectList`).
  * The resulting `audience` is at least the `visibility` of the update.
  * For the given `filter` and `update` the capability-granting predicate (`updatepolicy`) gives the session user enough access.

## Issues

Issues I'm aware of:
* By combining two `Update`s to the same field you can end up with an `update` predicate equivalent to `False` which will grant you full access. I don't know `Persistent` runtime behavior in this case, but we could implement a runtime check to avoid this case as an easy fix. I don't know if we can prevent this statically.
* I made `Update` invariant on all predicates to make things easier. This may be uncomfortable, but we can revisit this later.
* I didn't use operators to rule out the problems with LH not exporting refined signatures. We can also revisit this later.

## Example
A models file using update policies can be found [here](https://github.com/nilehmann/binah-apps/blob/master/wishlist/src/Model.binah) with the corresponding generated [Model.hs](https://github.com/nilehmann/binah-apps/blob/master/wishlist/src/Model.hs). An example of code doing updates can be found [here](https://github.com/nilehmann/binah-apps/blob/master/wishlist/src/Controllers/Wish.hs#L183).